### PR TITLE
Update utils.py to fix `Index out of error`

### DIFF
--- a/anlp_grading/utils.py
+++ b/anlp_grading/utils.py
@@ -59,7 +59,7 @@ def compare_outputs(std, result):
         result_lines = open(result).readlines()
         for idx, line1 in enumerate(open(std)):
             expected = line1.split('|||')[0].strip()
-            predicted = result_lines[idx].split('|||')[2].strip()
+            predicted = result_lines[idx].split('|||')[0].strip()
             same.append(1 if predicted == expected else 0)
         return sum(same) / len(same)
     except Exception as e:


### PR DESCRIPTION
The output of `classifier.py` should be in format `{prediction} ||| {sentence}` as given [here](https://github.com/neubig/minbert-assignment/blob/main/classifier.py#L241).
Thus line 62 of `utils.py` should be taking the first element instead of the third one.